### PR TITLE
dojson: fix physical description for page count

### DIFF
--- a/rero_ebooks/dojson/json/model.py
+++ b/rero_ebooks/dojson/json/model.py
@@ -175,12 +175,17 @@ def publisher_name(self, key, value):
 @cantook_json.over('physical_description', 'page_count')
 @utils.for_each_value
 @utils.filter_values
+@utils.ignore_value
 def physical_description(self, key, value):
     """Physical description transformation.
 
     extent (Number of physical pages, volumes...): Marc21 300 $a field.
     """
-    return {'extent': str(value)}
+    extent = None
+    if int(value) != 0:
+        pages = "{value} pages".format(value=value)
+        extent = {'extent': pages}
+    return extent
 
 
 @cantook_json.over('summary', 'summary')

--- a/tests/unit/test_dojson.py
+++ b/tests/unit/test_dojson.py
@@ -160,7 +160,7 @@ def test_json_physical_description():
     }
     assert cantook_json.do(data) == {
         '__order__': ['physical_description'],
-        'physical_description': [{'extent': '1234'}]
+        'physical_description': [{'extent': '1234 pages'}]
     }
 
 


### PR DESCRIPTION
* Adds the text "pages" for the pysical description of page count.
* Fixes the creation of pysical descriptions if the page count is 0
